### PR TITLE
Space before period after an anchor tag

### DIFF
--- a/lib/reverse_markdown/mapper.rb
+++ b/lib/reverse_markdown/mapper.rb
@@ -166,7 +166,7 @@ module ReverseMarkdown
           end
         when :a
           if !element.text.strip.empty? && element['href'] && !element['href'].start_with?('#')
-            "](#{element['href']}#{title_markdown(element)}) "
+            "](#{element['href']}#{title_markdown(element)})"
           else
             ""
           end

--- a/spec/assets/anchors.html
+++ b/spec/assets/anchors.html
@@ -4,6 +4,7 @@
     <a href="http://foobar.com">Foobar</a>
     <a href="http://foobar.com" title="f***** up beyond all recognition">Fubar</a>
     <a href="http://strong.foobar.com"><strong>Strong foobar</strong></a>
+    Period after the anchor: there shouldn't be an extra space after the <a href="http://foobar.com">anchor</a>. But inline, <a href="http://foobar.com">there</a> should be a space.
 
     ignore <a href="foo.html">   </a> anchor tags with no link text
     pass through the text of <a href="#content">internal jumplinks</a> without treating them as links

--- a/spec/components/anchors_spec.rb
+++ b/spec/components/anchors_spec.rb
@@ -13,6 +13,8 @@ describe ReverseMarkdown::Mapper do
   it { should include ' ![](http://foobar.com/logo.png) ' }
   it { should include ' ![foobar image](http://foobar.com/foobar.png) ' }
   it { should include ' ![foobar image 2](http://foobar.com/foobar2.png "this is the foobar image 2") ' }
+  it { should include 'extra space after the [anchor](http://foobar.com).'}
+  it { should include 'But inline, [there](http://foobar.com) should be a space.'}
 
   context "links to ignore" do
     it { should include ' ignore anchor tags with no link text ' }


### PR DESCRIPTION
When you have an anchor tag followed by a period at the end of a sentence, you would get the anchor in Markdown, a space, and then the period. I have eliminated the extra space so that you now get the anchor and then the period.
