### PR TITLE
Nested indentation fix for nested list items with adjacent parent list items

### DIFF
--- a/lib/reverse_markdown/converters/li.rb
+++ b/lib/reverse_markdown/converters/li.rb
@@ -5,7 +5,7 @@ module ReverseMarkdown
         content     = treat_children(node)
         indentation = indentation_for(node)
         prefix      = prefix_for(node)
-        "#{indentation}#{prefix}#{content}\n"
+        "#{indentation}#{prefix}#{content.chomp}\n"
       end
 
       def prefix_for(node)

--- a/spec/assets/lists.html
+++ b/spec/assets/lists.html
@@ -76,7 +76,7 @@
       <li>three</li>
     </ol>
 
-    a nested list with adjacent list items
+    a nested list between adjacent list items
     <ul>
       <li>alpha</li>
       <li>bravo

--- a/spec/assets/lists.html
+++ b/spec/assets/lists.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    some text...
+    <p>some text...</p>
 
     <ul>
       <li>unordered list entry</li>
@@ -26,10 +26,10 @@
       </li>
     </ol>
 
-    a nested list with no whitespace:
+    <p>a nested list with no whitespace:</p>
     <ul><li>item a</li><li>item b<ul><li>item bb</li><li>item bc</li></ul></li></ul>
 
-    a nested list with lots of whitespace:
+    <p>a nested list with lots of whitespace:</p>
     <ul>  <li>  item   wa  </li>  <li> item wb <ul> <li> item wbb </li> <li> item wbc </li> </ul> </li> </ul>
 
     <ul>
@@ -76,7 +76,7 @@
       <li>three</li>
     </ol>
 
-    a nested list between adjacent list items
+    <p>a nested list between adjacent list items</p>
     <ul>
       <li>alpha</li>
       <li>bravo
@@ -92,7 +92,6 @@
       <li>charlie</li>
       <li>delta</li>
     </ul>
-
 
   </body>
 </html>

--- a/spec/assets/lists.html
+++ b/spec/assets/lists.html
@@ -76,5 +76,23 @@
       <li>three</li>
     </ol>
 
+    a nested list with adjacent list items
+    <ul>
+      <li>alpha</li>
+      <li>bravo
+        <ul>
+          <li>bravo alpha</li>
+          <li>bravo bravo
+            <ul>
+              <li>bravo bravo alpha</i>
+            </ul>
+          </li>
+        </ul>
+      </li>
+      <li>charlie</li>
+      <li>delta</li>
+    </ul>
+
+
   </body>
 </html>

--- a/spec/components/lists_spec.rb
+++ b/spec/components/lists_spec.rb
@@ -54,13 +54,14 @@ describe ReverseMarkdown do
     it { should include "3. three" }
   end
 
-  context "a nested list between adjacent list items" do
+  context "properly embeds a nested list between adjacent list items" do
     it { should match /\n- alpha\n/ }
-    it { should match /\n- bravo\n/ }
+    it { should match /\n- bravo/ }
     it { should match /\n  - bravo alpha\n/ }
-    it { should match /\n  - bravo bravo\n/ }
-    it { should match /\n    - bravo bravo alpha\n/ }
+    it { should match /\n  - bravo bravo/ }
+    it { should match /\n    - bravo bravo alpha/ }
     it { should match /\n- charlie\n/ }
     it { should match /\n- delta\n/ }
   end
+
 end

--- a/spec/components/lists_spec.rb
+++ b/spec/components/lists_spec.rb
@@ -54,12 +54,12 @@ describe ReverseMarkdown do
     it { should include "3. three" }
   end
 
-  context "a nested list with adjacent list items" do
+  context "a nested list between adjacent list items" do
     it { should match /\n- alpha\n/ }
     it { should match /\n- bravo\n/ }
-    it { should match /\n  - alpha alpha\n/ }
-    it { should match /\n  - alpha bravo\n/ }
-    it { should match /\n  - alpha bravo\n/ }
+    it { should match /\n  - bravo alpha\n/ }
+    it { should match /\n  - bravo bravo\n/ }
+    it { should match /\n    - bravo bravo alpha\n/ }
     it { should match /\n- charlie\n/ }
     it { should match /\n- delta\n/ }
   end

--- a/spec/components/lists_spec.rb
+++ b/spec/components/lists_spec.rb
@@ -53,4 +53,14 @@ describe ReverseMarkdown do
     it { should include "  2. two two" }
     it { should include "3. three" }
   end
+
+  context "a nested list with adjacent list items" do
+    it { should match /\n- alpha\n/ }
+    it { should match /\n- bravo\n/ }
+    it { should match /\n  - alpha alpha\n/ }
+    it { should match /\n  - alpha bravo\n/ }
+    it { should match /\n  - alpha bravo\n/ }
+    it { should match /\n- charlie\n/ }
+    it { should match /\n- delta\n/ }
+  end
 end


### PR DESCRIPTION
Problem: given a nested list between adjacent list items like this:

````
<ul>
  <li>alpha</li>
  <li>bravo
    <ul>
      <li>bravo alpha</li>
      <li>bravo bravo
    </ul>
  </li>
  <li>charlie</li>
</ul>
````

Reverse markdown produces an extra newline:

````
- alpha
- bravo
  - bravo alpha
  - bravo bravo

- charlie
````

This PR fixes the `li` converter and removes the extra newline to produce this markdown:

````
- alpha
- bravo
  - bravo alpha
  - bravo bravo
- charlie
````

Specs included.