### PR TITLE
Updated config example so that it shows how to refer non-boolean values

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Or configure it block style on a initializer level
 
 ```ruby
 ReverseMarkdown.config do |config|
-  config.ignore_unknown_tags = false
-  config.github_flavored     = true
+  config.unknown_tags     = :bypass
+  config.github_flavored  = true
 end
 ```
 


### PR DESCRIPTION
Also changed `config.ignore_unknown_tags`, since the doc previously states it's called `config.unknown_tags`

I could not get config.ignore_unknown_tags to work, but it works with the change I described here :)
