### PR TITLE
Proper handling of non breaking space

### DIFF
--- a/lib/reverse_markdown/cleaner.rb
+++ b/lib/reverse_markdown/cleaner.rb
@@ -2,7 +2,8 @@ module ReverseMarkdown
   class Cleaner
 
     def tidy(string)
-      result = remove_inner_whitespaces(string)
+      result = preserve_trailing_nbsp(string)
+      result = remove_inner_whitespaces(result)
       result = remove_newlines(result)
       result = remove_leading_newlines(result)
       result = clean_tag_borders(result)
@@ -57,6 +58,12 @@ module ReverseMarkdown
 
     def clean_punctuation_characters(string)
       string.gsub(/(\*\*|~~|__)\s([\.!\?'"])/, "\\1".strip + "\\2")
+    end
+
+    # Make sure non breaking spaces that borders up to
+    # emphasis will be preserved. 
+    def preserve_trailing_nbsp(string)
+      string.gsub(/\u00a0((\*|~|_){1,2})/, "&nbsp;\\1")
     end
 
     private

--- a/spec/assets/paragraphs.html
+++ b/spec/assets/paragraphs.html
@@ -11,5 +11,14 @@
         <code>Content</code>
       </pre>
     </p>
+    <p>
+      <strong>Trailing whitespace: </strong>
+    </p>
+    <p>
+      <strong>Trailing non-breaking space:&nbsp;</strong>
+    </p>
+    <p>
+      <strong><em>Combination:&nbsp;</em></strong>
+    </p>
   </body>
 </html>

--- a/spec/components/paragraphs_spec.rb
+++ b/spec/components/paragraphs_spec.rb
@@ -9,4 +9,7 @@ describe ReverseMarkdown do
   it { should_not start_with "\n\n" }
   it { should start_with "First content\n\nSecond content\n\n" }
   it { should include "\n\n_Complex_\n\n    Content" }
+  it { should include "**Trailing whitespace:**" }
+  it { should include "**Trailing non-breaking space:&nbsp;**" }
+  it { should include "**_Combination:&nbsp;_**" }
 end


### PR DESCRIPTION
The parser is incorrect when handling text with a trailing `&nbsp;` inside emphasis such as `<em>` or `<strong>`. Browsers usually convert a trailing space into a HTML entity. However, it seems that nokogiri and reverse_markdown together converts it back to a space, which mess up the markdown.

Works well:
`ReverseMarkdown.convert '<em>feelings: </em>'`
`=> " *feelings:* "`

Not valid markdown:
`ReverseMarkdown.convert '<em>feelings:&nbsp;</em>'`
`=> " *feelings: * "`

I've added a cleanup method to handle this scenario and convert the UTF-8 non-breaking space into a &nbsp;. I think that is better than trimming it, as the &nbsp; seems to be intentional space to be shown.
