### PR TITLE
Preserve Github Flavor Markdown code block language information

### DIFF
--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -5,7 +5,9 @@ module ReverseMarkdown
     class Pre < Base
       def convert(node)
         if ReverseMarkdown.config.github_flavored
-          "```\n" << node.text.strip << "\n```\n"
+          highlight_match = node.parent['class'].nil? ? nil : node.parent['class'].match(/highlight highlight-([a-zA-Z0-9]+)/)
+          language_string = highlight_match ? " #{highlight_match[1]}" : ''
+          "```#{language_string}\n" << node.text.strip << "\n```\n"
         else
           "\n\n    " << node.text.strip.lines.to_a.join("    ") << "\n\n"
         end


### PR DESCRIPTION
Just a small change to improve code block handling, mostly self-explanatory.
