### PR TITLE
Syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ Gemfile.lock
 pkg/*
 coverage/*
 TODO
+## JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/

--- a/lib/reverse_markdown.rb
+++ b/lib/reverse_markdown.rb
@@ -32,6 +32,7 @@ require 'reverse_markdown/converters/tr'
 require 'reverse_markdown/highlighters'
 require 'reverse_markdown/highlighters/base'
 require 'reverse_markdown/highlighters/confluence'
+require 'reverse_markdown/highlighters/dobell'
 require 'reverse_markdown/highlighters/plain'
 
 module ReverseMarkdown

--- a/lib/reverse_markdown.rb
+++ b/lib/reverse_markdown.rb
@@ -29,6 +29,10 @@ require 'reverse_markdown/converters/table'
 require 'reverse_markdown/converters/td'
 require 'reverse_markdown/converters/text'
 require 'reverse_markdown/converters/tr'
+require 'reverse_markdown/highlighters'
+require 'reverse_markdown/highlighters/base'
+require 'reverse_markdown/highlighters/confluence'
+require 'reverse_markdown/highlighters/plain'
 
 module ReverseMarkdown
 

--- a/lib/reverse_markdown/config.rb
+++ b/lib/reverse_markdown/config.rb
@@ -23,5 +23,9 @@ module ReverseMarkdown
     def github_flavored
       @inline_options[:github_flavored] || @github_flavored
     end
+
+    def syntax_highlight
+      @inline_options[:syntax_highlight] || @syntax_highlight
+    end
   end
 end

--- a/lib/reverse_markdown/config.rb
+++ b/lib/reverse_markdown/config.rb
@@ -15,7 +15,7 @@ module ReverseMarkdown
     def reset
       @unknown_tags    = :pass_through
       @github_flavored = false
-      @syntax_highlight = :text
+      @syntax_highlight = :plain
     end
   end
 end

--- a/lib/reverse_markdown/config.rb
+++ b/lib/reverse_markdown/config.rb
@@ -1,6 +1,6 @@
 module ReverseMarkdown
   class Config
-    attr_accessor :unknown_tags, :github_flavored
+    attr_accessor :unknown_tags, :github_flavored, :syntax_highlight
 
     def initialize
       reset
@@ -15,6 +15,7 @@ module ReverseMarkdown
     def reset
       @unknown_tags    = :pass_through
       @github_flavored = false
+      @syntax_highlight = :text
     end
   end
 end

--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -12,6 +12,13 @@ module ReverseMarkdown
       end
       private
       def lang(node)
+        brush = ""
+        unless node['class'].to_s.empty?
+          case
+            when x
+          end
+        end
+        return brush
       end
     end
 

--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -12,13 +12,7 @@ module ReverseMarkdown
       end
       private
       def lang(node)
-        brush = ""
-        unless node['class'].to_s.empty?
-          case
-            when x
-          end
-        end
-        return brush
+        ReverseMarkdown::Highlighters.lookup(ReverseMarkdown.config.syntax_highlight).highlight(node)
       end
     end
 

--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -5,10 +5,13 @@ module ReverseMarkdown
     class Pre < Base
       def convert(node)
         if ReverseMarkdown.config.github_flavored
-          "```\n" << node.text.strip << "\n```\n"
+          "\n```#{lang(node)}\n" << node.text.strip << "\n```\n"
         else
           "\n\n    " << node.text.strip.lines.to_a.join("    ") << "\n\n"
         end
+      end
+      private
+      def lang(node)
       end
     end
 

--- a/lib/reverse_markdown/highlighters.rb
+++ b/lib/reverse_markdown/highlighters.rb
@@ -6,7 +6,7 @@ module ReverseMarkdown
     end
 
     def self.lookup(type)
-      @@highlihters[type.to_sym] or ReverseMarkdown::Highlighters::Plain.new
+      @@highlihters[type.to_sym] or ReverseMarkdown::Highlighters::Dobell.new
     end
   end
 end

--- a/lib/reverse_markdown/highlighters.rb
+++ b/lib/reverse_markdown/highlighters.rb
@@ -6,7 +6,7 @@ module ReverseMarkdown
     end
 
     def self.lookup(type)
-      @@highlihters[type.to_sym] or ReverseMarkdown::Highlighters::Dobell.new
+      @@highlihters[type.to_sym] or ReverseMarkdown::Highlighters::Plain.new
     end
   end
 end

--- a/lib/reverse_markdown/highlighters.rb
+++ b/lib/reverse_markdown/highlighters.rb
@@ -1,0 +1,12 @@
+module ReverseMarkdown
+  module Highlighters
+    def self.register(type, highlighter)
+      @@highlihters ||= {}
+      @@highlihters[type.to_sym] = highlighter
+    end
+
+    def self.lookup(type)
+      @@highlihters[type.to_sym] or ReverseMarkdown::Highlighters::Plain.new
+    end
+  end
+end

--- a/lib/reverse_markdown/highlighters/base.rb
+++ b/lib/reverse_markdown/highlighters/base.rb
@@ -1,0 +1,9 @@
+module ReverseMarkdown
+  module Highlighters
+    class Base
+      def highlight_code(node)
+        ReverseMarkdown::Highlighters.lookup(ReverseMarkdown.config.syntax_highlight).highlight(node)
+      end
+    end
+  end
+end

--- a/lib/reverse_markdown/highlighters/base.rb
+++ b/lib/reverse_markdown/highlighters/base.rb
@@ -1,8 +1,7 @@
 module ReverseMarkdown
   module Highlighters
     class Base
-      def highlight_code(node)
-        ReverseMarkdown::Highlighters.lookup(ReverseMarkdown.config.syntax_highlight).highlight(node)
+      def validate(lang)
       end
     end
   end

--- a/lib/reverse_markdown/highlighters/confluence.rb
+++ b/lib/reverse_markdown/highlighters/confluence.rb
@@ -1,0 +1,6 @@
+module ReverseMarkdown
+  module Highlighters
+    class Confluence
+    end
+  end
+end

--- a/lib/reverse_markdown/highlighters/confluence.rb
+++ b/lib/reverse_markdown/highlighters/confluence.rb
@@ -1,6 +1,12 @@
 module ReverseMarkdown
   module Highlighters
-    class Confluence
+    class Confluence < Base
+      def highlight(node)
+        brush = node['class'].split(';').map.select { |e| e.strip.start_with?('brush:') }[0] unless node['class'].to_s.empty?
+        brush.to_s.empty?? '' : brush.match(/:(.+)$/)[1].strip
+      end
     end
+
+    register :confluence, Confluence.new
   end
 end

--- a/lib/reverse_markdown/highlighters/dobell.rb
+++ b/lib/reverse_markdown/highlighters/dobell.rb
@@ -1,0 +1,12 @@
+module ReverseMarkdown
+  module Highlighters
+    class Dobell < Base
+      def highlight(node)
+        highlight_match = node.parent['class'].nil? ? nil : node.parent['class'].match(/highlight highlight-([a-zA-Z0-9]+)/)
+        highlight_match ? highlight_match[1] : ''
+      end
+    end
+
+    register :dobell, Dobell.new
+  end
+end

--- a/lib/reverse_markdown/highlighters/plain.rb
+++ b/lib/reverse_markdown/highlighters/plain.rb
@@ -1,0 +1,11 @@
+module ReverseMarkdown
+  module Highlighters
+    class Plain < Base
+      def highlight(node)
+        return ''
+      end
+    end
+
+    register :plain, Plain.new
+  end
+end

--- a/spec/lib/reverse_markdown/converters/pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/pre_spec.rb
@@ -29,9 +29,13 @@ describe ReverseMarkdown::Converters::Pre do
       node = node_for("<pre>puts foo</pre>")
       expect(converter.convert(node)).to include "```\nputs foo\n```"
     end
-    it 'includes the given highlight language' do
+    it 'includes the given highlight language dobell waty' do
       node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
       expect(converter.convert(node.children.first)).to include "```ruby\n"
+    end
+    it 'includes the given highlight language confluence way' do
+      node = node_for("<pre class=\"theme: Confluence; brush: php; gutter: false\">echo 'foo'</pre>")
+      expect(converter.convert(node)).to include "```\necho 'foo'\n```"
     end
   end
   context 'for github_flavored markdown confluence' do
@@ -43,6 +47,10 @@ describe ReverseMarkdown::Converters::Pre do
     it 'includes the given highlight language confluence way' do
       node = node_for("<pre class=\"theme: Confluence; brush: php; gutter: false\">echo 'foo'</pre>")
       expect(converter.convert(node)).to include "```php\n"
+    end
+    it 'includes the given highlight language dobell way' do
+      node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
+      expect(converter.convert(node.children.first)).to include "```\nputs foo\n```"
     end
   end
 end

--- a/spec/lib/reverse_markdown/converters/pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/pre_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+describe ReverseMarkdown::Converters::Pre do
+  let(:converter) { ReverseMarkdown::Converters::Pre.new }
+  context 'for standard markdown' do
+    before { ReverseMarkdown.config.github_flavored = false }
+    it 'converts with indentation' do
+      node = node_for("<pre>puts foo</pre>")
+      expect(converter.convert(node)).to include " puts foo\n"
+    end
+  end
+  context 'for github_flavored markdown' do
+    before { ReverseMarkdown.config.github_flavored = true }
+    it 'converts with backticks' do
+      node = node_for("<pre>puts foo</pre>")
+      expect(converter.convert(node)).to include "```\nputs foo\n```"
+    end
+    before { ReverseMarkdown.config.syntax_highlight = 'dobell' }
+    it 'includes the given highlight language' do
+      node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
+      expect(converter.convert(node.children.first)).to include "```ruby\n"
+    end
+    before { ReverseMarkdown.config.syntax_highlight = 'confluence' }
+    it 'includes the given highlight language confluence way' do
+      node = node_for("<pre class=\"theme: Confluence; brush: php; gutter: false\">echo 'foo'</pre>")
+      expect(converter.convert(node.children.first)).to include "```php\n"
+    end
+  end
+end

--- a/spec/lib/reverse_markdown/converters/pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/pre_spec.rb
@@ -8,21 +8,41 @@ describe ReverseMarkdown::Converters::Pre do
       expect(converter.convert(node)).to include " puts foo\n"
     end
   end
-  context 'for github_flavored markdown' do
+  context 'for github_flavored markdown plain' do
     before { ReverseMarkdown.config.github_flavored = true }
     it 'converts with backticks' do
       node = node_for("<pre>puts foo</pre>")
       expect(converter.convert(node)).to include "```\nputs foo\n```"
     end
-    before { ReverseMarkdown.config.syntax_highlight = 'dobell' }
+    it 'includes the given highlight language' do
+      node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
+      expect(converter.convert(node.children.first)).to include "```\nputs foo\n```"
+    end
+    it 'includes the given highlight language confluence way' do
+      node = node_for("<pre class=\"theme: Confluence; brush: php; gutter: false\">echo 'foo'</pre>")
+      expect(converter.convert(node)).to include "```\necho 'foo'\n```"
+    end
+  end
+  context 'for github_flavored markdown dobell' do
+    before { ReverseMarkdown.config.github_flavored = true, ReverseMarkdown.config.syntax_highlight = 'dobell' }
+    it 'converts with backticks' do
+      node = node_for("<pre>puts foo</pre>")
+      expect(converter.convert(node)).to include "```\nputs foo\n```"
+    end
     it 'includes the given highlight language' do
       node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
       expect(converter.convert(node.children.first)).to include "```ruby\n"
     end
-    before { ReverseMarkdown.config.syntax_highlight = 'confluence' }
+  end
+  context 'for github_flavored markdown confluence' do
+    before { ReverseMarkdown.config.github_flavored = true, ReverseMarkdown.config.syntax_highlight = 'confluence' }
+    it 'converts with backticks' do
+      node = node_for("<pre>puts foo</pre>")
+      expect(converter.convert(node)).to include "```\nputs foo\n```"
+    end
     it 'includes the given highlight language confluence way' do
       node = node_for("<pre class=\"theme: Confluence; brush: php; gutter: false\">echo 'foo'</pre>")
-      expect(converter.convert(node.children.first)).to include "```php\n"
+      expect(converter.convert(node)).to include "```php\n"
     end
   end
 end


### PR DESCRIPTION
There are numerous syntax highlighters on the web. I had to migrate a large documentation from Confluence to GitHub wiki. One of requirements was to preserve language specific highlighting. I hacked the code to get what I needed before bumping into similar implementation done by Benjamin-Dobell/reverse_markdown@73a1da89940c92b757605de06cc44ad35596c939. Then I figured out that more generic solution is needed: Solution that would make adding support for converting various syntax highlighting implementations easier.

The only difference to upstream implementation is that I add a new line before code block based on recommendation in [GitHub Flavoured Markdown](https://help.github.com/articles/github-flavored-markdown/) article.

I couldn't find out upon which syntax highlighter Benjamin based his implementation. Therefore I named highlighter after his last name. I will be happy to refactor once Benjamin provides name of syntax highlighter upon which he based his implementation.

Base highlighter class has unimplemented method validate. The idea is to validate languages based on GitHub supported [languages](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml) 

Defining which syntax highlighter is used in HTML to be converted aligns with upstream logic:
```ruby
ReverseMarkdown.config do |config|
  config.unknown_tags     = :bypass
  config.github_flavored  = true
  config.syntax_highlight = 'confluence'
end
``` 
or
```ruby
ReverseMarkdown.convert(input, unknown_tags: :bypass, github_flavored: true, syntax_highlight: 'confluence')
``` 
