### PR TITLE
Support syntax highlighting for pre tags

### DIFF
--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -3,10 +3,18 @@ module ReverseMarkdown
     class Pre < Base
       def convert(node)
         if ReverseMarkdown.config.github_flavored
-          "```\n" << node.text.strip << "\n```\n"
+          "\n```#{extract_language(node)}\n" << node.text.strip << "\n```\n"
         else
           "\n\n    " << node.text.strip.lines.to_a.join("    ") << "\n\n"
         end
+      end
+
+      private
+
+      def extract_language(node)
+        ReverseMarkdown.config.github_flavored or return
+        css_class = node.parent['class'].to_s
+        css_class[/highlight-([a-zA-Z0-9]+)/, 1]
       end
     end
 

--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -3,7 +3,7 @@ module ReverseMarkdown
     class Pre < Base
       def convert(node)
         if ReverseMarkdown.config.github_flavored
-          "\n```#{extract_language(node)}\n" << node.text.strip << "\n```\n"
+          "\n```#{language(node)}\n" << node.text.strip << "\n```\n"
         else
           "\n\n    " << node.text.strip.lines.to_a.join("    ") << "\n\n"
         end
@@ -11,10 +11,17 @@ module ReverseMarkdown
 
       private
 
-      def extract_language(node)
-        ReverseMarkdown.config.github_flavored or return
-        css_class = node.parent['class'].to_s
-        css_class[/highlight-([a-zA-Z0-9]+)/, 1]
+      def language(node)
+        lang = language_from_highlight_class(node)
+        lang || language_from_confluence_class(node)
+      end
+
+      def language_from_highlight_class(node)
+        node.parent['class'].to_s[/highlight-([a-zA-Z0-9]+)/, 1]
+      end
+
+      def language_from_confluence_class(node)
+        node['class'].to_s[/brush:\s?(:?.*);/, 1]
       end
     end
 

--- a/spec/lib/reverse_markdown/converters/pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/pre_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe ReverseMarkdown::Converters::Pre do
+
+  let(:converter) { ReverseMarkdown::Converters::Pre.new }
+
+  context 'for standard markdown' do
+    before { ReverseMarkdown.config.github_flavored = false }
+
+    it 'converts with indentation' do
+      node = node_for("<pre>puts foo</pre>")
+      expect(converter.convert(node)).to include "    puts foo\n"
+    end
+
+  end
+
+  context 'for github_flavored markdown' do
+    before { ReverseMarkdown.config.github_flavored = true }
+
+    it 'converts with backticks' do
+      node = node_for("<pre>puts foo</pre>")
+      expect(converter.convert(node)).to include "```\nputs foo\n```"
+    end
+
+    it 'includes the given highlight language' do
+      node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
+      expect(converter.convert(node.children.first)).to include "```ruby\n"
+    end
+  end
+
+end

--- a/spec/lib/reverse_markdown/converters/pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/pre_spec.rb
@@ -11,7 +11,6 @@ describe ReverseMarkdown::Converters::Pre do
       node = node_for("<pre>puts foo</pre>")
       expect(converter.convert(node)).to include "    puts foo\n"
     end
-
   end
 
   context 'for github_flavored markdown' do
@@ -22,9 +21,17 @@ describe ReverseMarkdown::Converters::Pre do
       expect(converter.convert(node)).to include "```\nputs foo\n```"
     end
 
-    it 'includes the given highlight language' do
-      node = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
-      expect(converter.convert(node.children.first)).to include "```ruby\n"
+    context 'syntax highlighting' do
+      it 'works for "highlight-lang" mechanism' do
+        div = node_for("<div class='highlight highlight-ruby'><pre>puts foo</pre></div>")
+        pre = div.children.first
+        expect(converter.convert(pre)).to include "```ruby\n"
+      end
+
+      it 'works for the confluence mechanism' do
+        pre = node_for("<pre class='theme: Confluence; brush: html/xml; gutter: false'>puts foo</pre>")
+        expect(converter.convert(pre)).to include "```html/xml\n"
+      end
     end
   end
 


### PR DESCRIPTION
Hello everyone,

This is my take on support for syntax highlighting. There have been #41 and #43 targeting the same topic already, but let me share some thoughts about that with you and have a quick discussion.

**Specs** Please add specs. Without specs (and examples) I can't find out if the pull requests are working or doing what they are supposed to.

**Which highlighter to support?** Like @schkovich pointed out, there are a lot of syntax highlighters out there. Supporting all of them inside the main gem would be too much. In this PR I only support the github way of highlighting, which fits the current policy within ReverseMarkdown - support plain and github flavored markdown only.

**Use existing tools** I like the idea of a plugin system for syntax highlighters, but while I was writing specs for #43 I got the feeling, that the existing converter system might already be able to solve this issue. Please take a look at https://gist.github.com/xijo/96bab44bcd04639436fa. It could be released as a gem as well, e.g. reverse_markdown-confluence.

Thanks for your work so far, I'm very curious to read your thoughts on this topic.