### PR TITLE
Add the ability to unregister a converter

### DIFF
--- a/lib/reverse_markdown/converters.rb
+++ b/lib/reverse_markdown/converters.rb
@@ -5,6 +5,10 @@ module ReverseMarkdown
       @@converters[tag_name.to_sym] = converter
     end
 
+    def self.unregister(tag_name)
+      @@converters.delete(tag_name.to_sym)
+    end
+
     def self.lookup(tag_name)
       @@converters[tag_name.to_sym] or default_converter(tag_name)
     end


### PR DESCRIPTION
This makes it possible to pass through a tag that has a defined converter by unregistering that tag's converter before calling convert. I had a requirement to always pass through `div` and `table` tags.

```ruby
ReverseMarkdown::Converters.unregister(:div)
ReverseMarkdown::Converters.unregister(:table)
markdown = ReverseMarkdown.convert(html)
```

Thanks for the great gem!