### PR TITLE
Preserve underscores + asterisks inside code spans

### DIFF
--- a/lib/reverse_markdown/converters/text.rb
+++ b/lib/reverse_markdown/converters/text.rb
@@ -27,7 +27,9 @@ module ReverseMarkdown
         text = preserve_nbsp(text)
         text = remove_border_newlines(text)
         text = remove_inner_newlines(text)
-        escape_keychars text
+        text = escape_keychars(text)
+
+        preserve_keychars_within_backticks(text)
       end
 
       def preserve_nbsp(text)
@@ -40,6 +42,12 @@ module ReverseMarkdown
 
       def remove_inner_newlines(text)
         text.tr("\n\t", ' ').squeeze(' ')
+      end
+
+      def preserve_keychars_within_backticks(text)
+        text.gsub(/`.*?`/) do |match|
+          match.gsub('\_', '_').gsub('\*', '*')
+        end
       end
     end
 

--- a/spec/lib/reverse_markdown/converters/text_spec.rb
+++ b/spec/lib/reverse_markdown/converters/text_spec.rb
@@ -28,4 +28,29 @@ describe ReverseMarkdown::Converters::Text do
     expect(result).to eq "foo&nbsp;bar &nbsp;"
   end
 
+  context 'within backticks' do
+    it "preserves single underscores" do
+      input = node_for("<p>`foo_bar`</p>")
+      result = converter.convert(input)
+      expect(result).to eq '`foo_bar`'
+    end
+
+    it "preserves multiple underscores" do
+      input = node_for("<p>`foo_bar __example__`</p>")
+      result = converter.convert(input)
+      expect(result).to eq '`foo_bar __example__`'
+    end
+
+    it "preserves single asterisks" do
+      input = node_for("<p>`def foo *args`</p>")
+      result = converter.convert(input)
+      expect(result).to eq '`def foo *args`'
+    end
+
+    it "preserves multiple asterisks" do
+      input = node_for("<p>`def foo 2***3`</p>")
+      result = converter.convert(input)
+      expect(result).to eq '`def foo 2***3`'
+    end
+  end
 end


### PR DESCRIPTION
Related to https://github.com/xijo/reverse_markdown/issues/46.

Converting a `p` tag which includes code with underscores or asterisks within backticks results in escaped characters:

```
ReverseMarkdown.convert("<p>`foo_bar 2**3`</p>")
=> "`foo\\_bar 2\\*\\*3`\n\n"
```
This PR makes sure to preserve these characters when within backticks.

Thanks for the gem :)

/cc @xijo 