### PR TITLE
Handle leading/trailing whitespace in em and strong

### DIFF
--- a/lib/reverse_markdown/converters/em.rb
+++ b/lib/reverse_markdown/converters/em.rb
@@ -6,7 +6,7 @@ module ReverseMarkdown
         if content.strip.empty? || already_italic?(node)
           content
         else
-          "_#{content}_"
+          "#{content.match(/^\s*/)[0]}_#{content.strip}_#{content.match(/\s*$/)[0]}"
         end
       end
 

--- a/lib/reverse_markdown/converters/strong.rb
+++ b/lib/reverse_markdown/converters/strong.rb
@@ -6,7 +6,7 @@ module ReverseMarkdown
         if content.strip.empty? || already_strong?(node)
           content
         else
-          "**#{content}**"
+          "#{content.match(/^\s*/)[0]}**#{content.strip}**#{content.match(/\s*$/)[0]}"
         end
       end
 

--- a/spec/assets/basic.html
+++ b/spec/assets/basic.html
@@ -14,6 +14,10 @@
     before <em> <em> <br /> </em> </em> and after em tags containing whitespace
     <em><em>double em tags</em></em>
     <p><em><em>double em tags in p tag</em></em></p>
+    <em> em with leading and trailing </em>whitespace
+    <em>     
+        em with extra leading and trailing   
+        </em>whitespace
 
     <strong>strong tag content</strong>
     before <strong></strong> and after empty strong tags
@@ -27,6 +31,10 @@
           double strong tags containing whitespace
         </strong>
       </strong> after
+    <strong> strong with leading and trailing </strong>whitespace
+    <strong>     
+        strong with extra leading and trailing   
+        </strong>whitespace
 
     <b>b tag content</b>
     <i>i tag content</i>

--- a/spec/components/basic_spec.rb
+++ b/spec/components/basic_spec.rb
@@ -19,6 +19,8 @@ describe ReverseMarkdown do
   it { should match /before and after em tags containing whitespace/ }
   it { should match /_double em tags_/ }
   it { should match /_double em tags in p tag_/ }
+  it { should match /_em with leading and trailing_ whitespace/ }
+  it { should match /_em with extra leading and trailing_ whitespace/ }
 
   it { should match /\*\*strong tag content\*\*/ }
   it { should match /before and after empty strong tags/ }
@@ -26,6 +28,8 @@ describe ReverseMarkdown do
   it { should match /\*\*double strong tags\*\*/ }
   it { should match /\*\*double strong tags in p tag\*\*/ }
   it { should match /before \*\*double strong tags containing whitespace\*\* after/ }
+  it { should match /\*\*strong with leading and trailing\*\* whitespace/ }
+  it { should match /\*\*strong with extra leading and trailing\*\* whitespace/ }
 
   it { should match /_i tag content_/ }
   it { should match /\*\*b tag content\*\*/ }

--- a/spec/components/from_the_wild_spec.rb
+++ b/spec/components/from_the_wild_spec.rb
@@ -7,9 +7,7 @@ describe ReverseMarkdown do
   subject { ReverseMarkdown.convert(input) }
 
   it "should make sense of strong-crazy markup (as seen in the wild)" do
-    expect(subject).to eq '**.' + "  \n" +
-      ' \*\*\* intentcast ** : logo design' + "   \n" +
-      "**.**\n\n"
+    expect(subject).to eq "**.  \n \\*\\*\\* intentcast** : logo design   \n **.**\n\n"
   end
 
 end


### PR DESCRIPTION
Code like `<em> em with leading and trailing </em>whitespace` failed to convert properly.

The "from the wild" test didn't have the correct expected output. It actually had the same whitespace issue that I fixed. 