### PR TITLE
Don't try to clean lines that only contain whitespace

### DIFF
--- a/lib/reverse_markdown/cleaner.rb
+++ b/lib/reverse_markdown/cleaner.rb
@@ -62,6 +62,7 @@ module ReverseMarkdown
     private
 
     def preserve_border_whitespaces(string, options = {}, &block)
+      return string if string =~ /\A\s*\Z/
       default_border = options.fetch(:default_border, '')
       string_start   = present_or_default(string[/\A\s*/], default_border)
       string_end     = present_or_default(string[/\s*\Z/], default_border)

--- a/spec/lib/reverse_markdown/cleaner_spec.rb
+++ b/spec/lib/reverse_markdown/cleaner_spec.rb
@@ -45,6 +45,11 @@ describe ReverseMarkdown::Cleaner do
       result = cleaner.remove_inner_whitespaces("foo\t \tbar")
       expect(result).to eq "foo bar"
     end
+
+    it 'keeps lines that only contain whitespace' do
+      result = cleaner.remove_inner_whitespaces("foo \nbar \n \n  \nfoo")
+      expect(result).to eq "foo \nbar \n \n  \nfoo"
+    end
   end
 
   describe '#clean_punctuation_characters' do


### PR DESCRIPTION
The cleaner would duplicate lines than only contained whitespace because the entire string was considered both the beginning and the end of the string.

```
foo \nbar \n \n  \nfoo
```
was "cleaned" to be
```
foo \nbar \n \n \n  \n  \nfoo
```

This fixes that.