### PR TITLE
Remove extra space before links

### DIFF
--- a/lib/reverse_markdown/converters/a.rb
+++ b/lib/reverse_markdown/converters/a.rb
@@ -10,9 +10,15 @@ module ReverseMarkdown
           name
         else
           link = "[#{name}](#{href}#{title})"
-          link.prepend(' ') if node.previous_sibling.to_s.end_with?('!')
+          link.prepend(' ') if prepend_space?(node)
           link
         end
+      end
+
+      private
+
+      def prepend_space?(node)
+        node.at_xpath("preceding::text()[1]").to_s.end_with?('!')
       end
     end
 

--- a/lib/reverse_markdown/converters/a.rb
+++ b/lib/reverse_markdown/converters/a.rb
@@ -9,7 +9,9 @@ module ReverseMarkdown
         if href.to_s.start_with?('#') || href.to_s.empty? || name.empty?
           name
         else
-          " [#{name}](#{href}#{title})"
+          link = "[#{name}](#{href}#{title})"
+          link.prepend(' ') if node.previous_sibling.to_s.end_with?('!')
+          link
         end
       end
     end

--- a/spec/assets/anchors.html
+++ b/spec/assets/anchors.html
@@ -4,7 +4,8 @@
     <a href="http://foobar.com">Foobar</a>
     <a href="http://foobar.com" title="f***** up beyond all recognition">Fubar</a>
     <a href="http://strong.foobar.com"><strong>Strong foobar</strong></a>
-    Period after the anchor: there shouldn't be an extra space after the <a href="http://foobar.com">anchor</a>. But inline, <a href="http://foobar.com">there</a> should be a space.
+    There should be no extra space before and after the anchor (<a href="http://foobar.com">stripped</a>).
+    Exception: after an !<a href="http://not.an.image.foobar.com">there</a> should be an extra space.
 
     ignore <a href="foo.html">   </a> anchor tags with no link text
     not ignore <a href="foo.html"><img src="image.png" alt="An Image" /></a> anchor tags with images

--- a/spec/assets/anchors.html
+++ b/spec/assets/anchors.html
@@ -6,6 +6,7 @@
     <a href="http://strong.foobar.com"><strong>Strong foobar</strong></a>
     There should be no extra space before and after the anchor (<a href="http://foobar.com">stripped</a>).
     Exception: after an !<a href="http://not.an.image.foobar.com">there</a> should be an extra space.
+    Even with stripped elements inbetween: !<span><a href="http://still.not.an.image.foobar.com">there</a></span> should be an extra space.
 
     ignore <a href="foo.html">   </a> anchor tags with no link text
     not ignore <a href="foo.html"><img src="image.png" alt="An Image" /></a> anchor tags with images

--- a/spec/components/anchors_spec.rb
+++ b/spec/components/anchors_spec.rb
@@ -15,6 +15,7 @@ describe ReverseMarkdown do
   it { is_expected.to include ' ![foobar image 2](http://foobar.com/foobar2.png "this is the foobar image 2") ' }
   it { is_expected.to include 'no extra space before and after the anchor ([stripped](http://foobar.com)).'}
   it { is_expected.to include 'after an ! [there](http://not.an.image.foobar.com) should be an extra space.'}
+  it { is_expected.to include 'with stripped elements inbetween: ! [there](http://still.not.an.image.foobar.com) should be an extra space.'}
 
   context "links to ignore" do
     it { is_expected.to include ' ignore anchor tags with no link text ' }

--- a/spec/components/anchors_spec.rb
+++ b/spec/components/anchors_spec.rb
@@ -6,15 +6,15 @@ describe ReverseMarkdown do
   let(:document) { Nokogiri::HTML(input) }
   subject { ReverseMarkdown.convert(input) }
 
-  it { is_expected.to include ' [Foobar](http://foobar.com) ' }
-  it { is_expected.to include ' [Fubar](http://foobar.com "f\*\*\*\*\* up beyond all recognition") ' }
-  it { is_expected.to include ' [**Strong foobar**](http://strong.foobar.com) ' }
+  it { is_expected.to include '[Foobar](http://foobar.com)' }
+  it { is_expected.to include '[Fubar](http://foobar.com "f\*\*\*\*\* up beyond all recognition")' }
+  it { is_expected.to include '[**Strong foobar**](http://strong.foobar.com)' }
 
   it { is_expected.to include ' ![](http://foobar.com/logo.png) ' }
   it { is_expected.to include ' ![foobar image](http://foobar.com/foobar.png) ' }
   it { is_expected.to include ' ![foobar image 2](http://foobar.com/foobar2.png "this is the foobar image 2") ' }
-  it { is_expected.to include 'extra space after the [anchor](http://foobar.com).'}
-  it { is_expected.to include 'But inline, [there](http://foobar.com) should be a space.'}
+  it { is_expected.to include 'no extra space before and after the anchor ([stripped](http://foobar.com)).'}
+  it { is_expected.to include 'after an ! [there](http://not.an.image.foobar.com) should be an extra space.'}
 
   context "links to ignore" do
     it { is_expected.to include ' ignore anchor tags with no link text ' }


### PR DESCRIPTION
As already described in issue #56, given:
```html
(<a href="http://foobar.com">link</a>)
```
I would expect to see:
```markdown
([link](http://foobar.com))
```
But the actual result has an extra space after the left parenthesis:
```markdown
( [link](http://foobar.com))
```

The implementation also handles the case when there is an exclamation mark before the link (by adding a space).
