### PR TITLE
Fix text escaping

### DIFF
--- a/lib/reverse_markdown/converters/text.rb
+++ b/lib/reverse_markdown/converters/text.rb
@@ -29,11 +29,18 @@ module ReverseMarkdown
         text = remove_inner_newlines(text)
         text = escape_keychars(text)
 
-        preserve_keychars_within_backticks(text)
+        text = preserve_keychars_within_backticks(text)
+        text = preserve_tags(text)
+        
+        text
       end
 
       def preserve_nbsp(text)
         text.gsub(/\u00A0/, "&nbsp;")
+      end
+      
+      def preserve_tags(text)
+        text.gsub(/[<>]/, '>' => '\>', '<' => '\<')
       end
 
       def remove_border_newlines(text)

--- a/spec/lib/reverse_markdown/converters/text_spec.rb
+++ b/spec/lib/reverse_markdown/converters/text_spec.rb
@@ -28,6 +28,12 @@ describe ReverseMarkdown::Converters::Text do
     expect(result).to eq "foo&nbsp;bar &nbsp;"
   end
 
+  it 'keeps escaped HTML-ish characters' do
+    input = node_for("<p>&lt;foo&gt;</p>")
+    result = converter.convert(input)
+    expect(result).to eq '\<foo\>'
+  end
+
   context 'within backticks' do
     it "preserves single underscores" do
       input = node_for("<p>`foo_bar`</p>")


### PR DESCRIPTION
At this time, the Markdown:

    <p>&lt;foo&gt;</p>

…reverses into:

    <foo>

…which re-renders into HTML as:

    <p><foo></p>

This changeset changes the resulting Markdown to:

    \<foo\>