### PR TITLE
allow default_border to be empty using config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The following options are available:
   - `bypass` - Ignore the unknown tag but try to convert its content
   - `raise` - Raise an error to let you know
 - `github_flavored` (default `false`) - use [github flavored markdown](https://help.github.com/articles/github-flavored-markdown) (yet only code blocks are supported)
+- `default_borders` (default `' '`) - how to handle tag borders. valid options are:
+  - `' '` - Add whitespace if there is none at tag borders.
+  - `''` - Do not not add whitespace.
 
 ### As options
 
@@ -84,6 +87,7 @@ Or configure it block style on a initializer level. These configurations will la
 ReverseMarkdown.config do |config|
   config.unknown_tags     = :bypass
   config.github_flavored  = true
+  config.default_borders  = ''
 end
 ```
 

--- a/lib/reverse_markdown/cleaner.rb
+++ b/lib/reverse_markdown/cleaner.rb
@@ -31,19 +31,19 @@ module ReverseMarkdown
     # Same for underscores and brackets.
     def clean_tag_borders(string)
       result = string.gsub(/\s?\*{2,}.*?\*{2,}\s?/) do |match|
-        preserve_border_whitespaces(match, default_border: ' ') do
+        preserve_border_whitespaces(match, default_border: ReverseMarkdown.config.default_borders) do
           match.strip.sub('** ', '**').sub(' **', '**')
         end
       end
 
       result = result.gsub(/\s?\_{2,}.*?\_{2,}\s?/) do |match|
-        preserve_border_whitespaces(match, default_border: ' ') do
+        preserve_border_whitespaces(match, default_border: ReverseMarkdown.config.default_borders) do
           match.strip.sub('__ ', '__').sub(' __', '__')
         end
       end
 
       result = result.gsub(/\s?~{2,}.*?~{2,}\s?/) do |match|
-        preserve_border_whitespaces(match, default_border: ' ') do
+        preserve_border_whitespaces(match, default_border: ReverseMarkdown.config.default_borders) do
           match.strip.sub('~~ ', '~~').sub(' ~~', '~~')
         end
       end

--- a/lib/reverse_markdown/config.rb
+++ b/lib/reverse_markdown/config.rb
@@ -1,13 +1,14 @@
 module ReverseMarkdown
   class Config
-    attr_accessor :unknown_tags, :github_flavored
+    attr_accessor :unknown_tags, :github_flavored, :default_borders
 
     def initialize
       @unknown_tags     = :pass_through
       @github_flavored  = false
-      @em_delimiter     = '_'
-      @strong_delimiter = '**'
+      @em_delimiter     = '_'.freeze
+      @strong_delimiter = '**'.freeze
       @inline_options   = {}
+      @default_borders  = ' '.freeze
     end
 
     def with(options = {})
@@ -23,6 +24,10 @@ module ReverseMarkdown
 
     def github_flavored
       @inline_options[:github_flavored] || @github_flavored
+    end
+
+    def default_borders
+      @inline_options[:default_borders] || @default_borders
     end
   end
 end

--- a/spec/assets/basic.html
+++ b/spec/assets/basic.html
@@ -14,8 +14,8 @@
     before <em> <em> <br /> </em> </em> and after em tags containing whitespace
     <em><em>double em tags</em></em>
     <p><em><em>double em tags in p tag</em></em></p>
-    <em> em with leading and trailing </em>whitespace
-    <em>     
+    a<em> em with leading and trailing </em>whitespace
+    a<em>     
         em with extra leading and trailing   
         </em>whitespace
 
@@ -31,8 +31,8 @@
           double strong tags containing whitespace
         </strong>
       </strong> after
-    <strong> strong with leading and trailing </strong>whitespace
-    <strong>     
+    a<strong> strong with leading and trailing </strong>whitespace
+    a<strong>     
         strong with extra leading and trailing   
         </strong>whitespace
 

--- a/spec/components/basic_spec.rb
+++ b/spec/components/basic_spec.rb
@@ -19,8 +19,8 @@ describe ReverseMarkdown do
   it { is_expected.to match /before and after em tags containing whitespace/ }
   it { is_expected.to match /_double em tags_/ }
   it { is_expected.to match /_double em tags in p tag_/ }
-  it { is_expected.to match /_em with leading and trailing_ whitespace/ }
-  it { is_expected.to match /_em with extra leading and trailing_ whitespace/ }
+  it { is_expected.to match /a _em with leading and trailing_ whitespace/ }
+  it { is_expected.to match /a _em with extra leading and trailing_ whitespace/ }
 
   it { is_expected.to match /\*\*strong tag content\*\*/ }
   it { is_expected.to match /before and after empty strong tags/ }
@@ -28,8 +28,8 @@ describe ReverseMarkdown do
   it { is_expected.to match /\*\*double strong tags\*\*/ }
   it { is_expected.to match /\*\*double strong tags in p tag\*\*/ }
   it { is_expected.to match /before \*\*double strong tags containing whitespace\*\* after/ }
-  it { is_expected.to match /\*\*strong with leading and trailing\*\* whitespace/ }
-  it { is_expected.to match /\*\*strong with extra leading and trailing\*\* whitespace/ }
+  it { is_expected.to match /a \*\*strong with leading and trailing\*\* whitespace/ }
+  it { is_expected.to match /a \*\*strong with extra leading and trailing\*\* whitespace/ }
 
   it { is_expected.to match /_i tag content_/ }
   it { is_expected.to match /\*\*b tag content\*\*/ }

--- a/spec/lib/reverse_markdown/cleaner_spec.rb
+++ b/spec/lib/reverse_markdown/cleaner_spec.rb
@@ -61,46 +61,96 @@ describe ReverseMarkdown::Cleaner do
   end
 
   describe '#clean_tag_borders' do
-    it 'removes not needed whitespaces from strong tags' do
-      input = "foo ** foobar ** bar"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "foo **foobar** bar"
+    context 'with default_border is set to space' do
+      before { ReverseMarkdown.config.default_borders = ' ' }
+
+      it 'removes not needed whitespaces from strong tags' do
+        input = "foo ** foobar ** bar"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "foo **foobar** bar"
+      end
+
+      it 'remotes leading or trailing whitespaces independently' do
+        input = "1 **fat ** 2 ** fat** 3"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 **fat** 2 **fat** 3"
+      end
+
+      it 'adds whitespaces if there are none' do
+        input = "1**fat**2"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 **fat** 2"
+      end
+
+      it "doesn't add whitespaces to underscore'ed elements if they are part of links" do
+        input = "![im__age](sou__rce)"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "![im__age](sou__rce)"
+      end
+
+      it "still cleans up whitespaces that aren't inside a link" do
+        input = "now __italic __with following [under__scored](link)"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "now __italic__ with following [under__scored](link)"
+      end
+
+      it 'cleans italic stuff as well' do
+        input = "1 __italic __ 2 __ italic__ 3__italic __4"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 __italic__ 2 __italic__ 3 __italic__ 4"
+      end
+
+      it 'cleans strikethrough stuff as well' do
+        input = "1 ~~italic ~~ 2 ~~ italic~~ 3~~italic ~~4"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 ~~italic~~ 2 ~~italic~~ 3 ~~italic~~ 4"
+      end
     end
 
-    it 'remotes leading or trailing whitespaces independently' do
-      input = "1 **fat ** 2 ** fat** 3"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "1 **fat** 2 **fat** 3"
-    end
+    context 'with default_border set to no space' do
+      before { ReverseMarkdown.config.default_borders = '' }
 
-    it 'adds whitespaces if there are none' do
-      input = "1**fat**2"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "1 **fat** 2"
-    end
+      it 'removes not needed whitespaces from strong tags' do
+        input = "foo ** foobar ** bar"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "foo **foobar** bar"
+      end
 
-    it "doesn't add whitespaces to underscore'ed elements if they are part of links" do
-      input = "![im__age](sou__rce)"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "![im__age](sou__rce)"
-    end
+      it 'remotes leading or trailing whitespaces independently' do
+        input = "1 **fat ** 2 ** fat** 3"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 **fat** 2 **fat** 3"
+      end
 
-    it "still cleans up whitespaces that aren't inside a link" do
-      input = "now __italic __with following [under__scored](link)"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "now __italic__ with following [under__scored](link)"
-    end
+      it 'adds whitespaces if there are none' do
+        input = "1**fat**2"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1**fat**2"
+      end
 
-    it 'cleans italic stuff as well' do
-      input = "1 __italic __ 2 __ italic__ 3__italic __4"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "1 __italic__ 2 __italic__ 3 __italic__ 4"
-    end
+      it "doesn't add whitespaces to underscore'ed elements if they are part of links" do
+        input = "![im__age](sou__rce)"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "![im__age](sou__rce)"
+      end
 
-    it 'cleans strikethrough stuff as well' do
-      input = "1 ~~italic ~~ 2 ~~ italic~~ 3~~italic ~~4"
-      result = cleaner.clean_tag_borders(input)
-      expect(result).to eq "1 ~~italic~~ 2 ~~italic~~ 3 ~~italic~~ 4"
+      it "still cleans up whitespaces that aren't inside a link" do
+        input = "now __italic __with following [under__scored](link)"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "now __italic__with following [under__scored](link)"
+      end
+
+      it 'cleans italic stuff as well' do
+        input = "1 __italic __ 2 __ italic__ 3__italic __4"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 __italic__ 2 __italic__ 3__italic__4"
+      end
+
+      it 'cleans strikethrough stuff as well' do
+        input = "1 ~~italic ~~ 2 ~~ italic~~ 3~~italic ~~4"
+        result = cleaner.clean_tag_borders(input)
+        expect(result).to eq "1 ~~italic~~ 2 ~~italic~~ 3~~italic~~4"
+      end
     end
   end
 


### PR DESCRIPTION
Based on our conversation here a while back, I wrote the following code:
https://github.com/xijo/reverse_markdown/commit/236a9afe4dc1b755914a712ca7e8c8e89d9b6ce0#commitcomment-11240524

This pull request adds a config option: `Default border`. Which set to a single whitespace as default. It will add extra border characters where the source does not have it. 

If we pass default border to be empty, this request allows resulting markdown to stay true to the source html.