### PR TITLE
Avoid traversing back up the tree

### DIFF
--- a/lib/reverse_markdown/converters/a.rb
+++ b/lib/reverse_markdown/converters/a.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class A < Base
-      def convert(node)
-        name  = treat_children(node)
+      def convert(node, state = {})
+        name  = treat_children(node, state)
         href  = node['href']
         title = extract_title(node)
 

--- a/lib/reverse_markdown/converters/base.rb
+++ b/lib/reverse_markdown/converters/base.rb
@@ -1,14 +1,14 @@
 module ReverseMarkdown
   module Converters
     class Base
-      def treat_children(node)
+      def treat_children(node, state)
         node.children.inject('') do |memo, child|
-          memo << treat(child)
+          memo << treat(child, state)
         end
       end
 
-      def treat(node)
-        ReverseMarkdown::Converters.lookup(node.name).convert(node)
+      def treat(node, state)
+        ReverseMarkdown::Converters.lookup(node.name).convert(node, state)
       end
 
       def escape_keychars(string)

--- a/lib/reverse_markdown/converters/blockquote.rb
+++ b/lib/reverse_markdown/converters/blockquote.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class Blockquote < Base
-      def convert(node)
-        content = treat_children(node).strip
+      def convert(node, state = {})
+        content = treat_children(node, state).strip
         content = ReverseMarkdown.cleaner.remove_newlines(content)
         '> ' << content.lines.to_a.join('> ')
       end

--- a/lib/reverse_markdown/converters/br.rb
+++ b/lib/reverse_markdown/converters/br.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Br < Base
-      def convert(node)
+      def convert(node, state = {})
         "  \n"
       end
     end

--- a/lib/reverse_markdown/converters/bypass.rb
+++ b/lib/reverse_markdown/converters/bypass.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class Bypass < Base
-      def convert(node)
-        treat_children(node)
+      def convert(node, state = {})
+        treat_children(node, state)
       end
     end
 

--- a/lib/reverse_markdown/converters/code.rb
+++ b/lib/reverse_markdown/converters/code.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Code < Base
-      def convert(node)
+      def convert(node, state = {})
         "`#{node.text}`"
       end
     end

--- a/lib/reverse_markdown/converters/del.rb
+++ b/lib/reverse_markdown/converters/del.rb
@@ -1,9 +1,9 @@
 module ReverseMarkdown
   module Converters
     class Del < Base
-      def convert(node)
-        content = treat_children(node)
-        if disabled? || content.strip.empty? || already_crossed_out?(node)
+      def convert(node, state = {})
+        content = treat_children(node, state.merge(already_crossed_out: true))
+        if disabled? || content.strip.empty? || state[:already_crossed_out]
           content
         else
           "~~#{content}~~"
@@ -16,10 +16,6 @@ module ReverseMarkdown
 
       def disabled?
         !enabled?
-      end
-
-      def already_crossed_out?(node)
-        node.ancestors('del').size > 0 || node.ancestors('strike').size > 0
       end
     end
 

--- a/lib/reverse_markdown/converters/div.rb
+++ b/lib/reverse_markdown/converters/div.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class Div < Base
-      def convert(node)
-        "\n" << treat_children(node) << "\n"
+      def convert(node, state = {})
+        "\n" << treat_children(node, state) << "\n"
       end
     end
 

--- a/lib/reverse_markdown/converters/drop.rb
+++ b/lib/reverse_markdown/converters/drop.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Drop < Base
-      def convert(node)
+      def convert(node, state = {})
         ''
       end
     end

--- a/lib/reverse_markdown/converters/em.rb
+++ b/lib/reverse_markdown/converters/em.rb
@@ -1,17 +1,13 @@
 module ReverseMarkdown
   module Converters
     class Em < Base
-      def convert(node)
-        content = treat_children(node)
-        if content.strip.empty? || already_italic?(node)
+      def convert(node, state = {})
+        content = treat_children(node, state.merge(already_italic: true))
+        if content.strip.empty? || state[:already_italic]
           content
         else
           "#{content[/^\s*/]}_#{content.strip}_#{content[/\s*$/]}"
         end
-      end
-
-      def already_italic?(node)
-        node.ancestors('italic').size > 0 || node.ancestors('em').size > 0
       end
     end
 

--- a/lib/reverse_markdown/converters/h.rb
+++ b/lib/reverse_markdown/converters/h.rb
@@ -1,9 +1,9 @@
 module ReverseMarkdown
   module Converters
     class H < Base
-      def convert(node)
+      def convert(node, state = {})
         prefix = '#' * node.name[/\d/].to_i
-        ["\n", prefix, ' ', treat_children(node), "\n"].join
+        ["\n", prefix, ' ', treat_children(node, state), "\n"].join
       end
     end
 

--- a/lib/reverse_markdown/converters/hr.rb
+++ b/lib/reverse_markdown/converters/hr.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Hr < Base
-      def convert(node)
+      def convert(node, state = {})
         "\n* * *\n"
       end
     end

--- a/lib/reverse_markdown/converters/ignore.rb
+++ b/lib/reverse_markdown/converters/ignore.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Ignore < Base
-      def convert(node)
+      def convert(node, state = {})
         '' # noop
       end
     end

--- a/lib/reverse_markdown/converters/img.rb
+++ b/lib/reverse_markdown/converters/img.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Img < Base
-      def convert(node)
+      def convert(node, state = {})
         alt   = node['alt']
         src   = node['src']
         title = extract_title(node)

--- a/lib/reverse_markdown/converters/li.rb
+++ b/lib/reverse_markdown/converters/li.rb
@@ -1,9 +1,9 @@
 module ReverseMarkdown
   module Converters
     class Li < Base
-      def convert(node)
-        content     = treat_children(node)
-        indentation = indentation_for(node)
+      def convert(node, state = {})
+        content     = treat_children(node, state)
+        indentation = indentation_from(state)
         prefix      = prefix_for(node)
         "#{indentation}#{prefix}#{content.chomp}\n"
       end
@@ -17,8 +17,8 @@ module ReverseMarkdown
         end
       end
 
-      def indentation_for(node)
-        length = node.ancestors('ol').size + node.ancestors('ul').size
+      def indentation_from(state)
+        length = state.fetch(:ol_count, 0)
         '  ' * [length - 1, 0].max
       end
     end

--- a/lib/reverse_markdown/converters/ol.rb
+++ b/lib/reverse_markdown/converters/ol.rb
@@ -1,8 +1,9 @@
 module ReverseMarkdown
   module Converters
     class Ol < Base
-      def convert(node)
-        "\n" << treat_children(node)
+      def convert(node, state = {})
+        ol_count = state.fetch(:ol_count, 0) + 1
+        "\n" << treat_children(node, state.merge(ol_count: ol_count))
       end
     end
 

--- a/lib/reverse_markdown/converters/p.rb
+++ b/lib/reverse_markdown/converters/p.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class P < Base
-      def convert(node)
-        "\n\n" << treat_children(node).strip << "\n\n"
+      def convert(node, state = {})
+        "\n\n" << treat_children(node, state).strip << "\n\n"
       end
     end
 

--- a/lib/reverse_markdown/converters/pass_through.rb
+++ b/lib/reverse_markdown/converters/pass_through.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class PassThrough < Base
-      def convert(node)
+      def convert(node, state = {})
         node.to_s
       end
     end

--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -1,7 +1,7 @@
 module ReverseMarkdown
   module Converters
     class Pre < Base
-      def convert(node)
+      def convert(node, state = {})
         if ReverseMarkdown.config.github_flavored
           "\n```#{language(node)}\n" << node.text.strip << "\n```\n"
         else

--- a/lib/reverse_markdown/converters/strong.rb
+++ b/lib/reverse_markdown/converters/strong.rb
@@ -1,17 +1,13 @@
 module ReverseMarkdown
   module Converters
     class Strong < Base
-      def convert(node)
-        content = treat_children(node)
-        if content.strip.empty? || already_strong?(node)
+      def convert(node, state = {})
+        content = treat_children(node, state.merge(already_strong: true))
+        if content.strip.empty? || state[:already_strong]
           content
         else
           "#{content[/^\s*/]}**#{content.strip}**#{content[/\s*$/]}"
         end
-      end
-
-      def already_strong?(node)
-        node.ancestors('strong').size > 0 || node.ancestors('b').size > 0
       end
     end
 

--- a/lib/reverse_markdown/converters/table.rb
+++ b/lib/reverse_markdown/converters/table.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class Table < Base
-      def convert(node)
-        "\n\n" << treat_children(node) << "\n"
+      def convert(node, state = {})
+        "\n\n" << treat_children(node, state) << "\n"
       end
     end
 

--- a/lib/reverse_markdown/converters/td.rb
+++ b/lib/reverse_markdown/converters/td.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class Td < Base
-      def convert(node)
-        content = treat_children(node)
+      def convert(node, state = {})
+        content = treat_children(node, state)
         " #{content} |"
       end
     end

--- a/lib/reverse_markdown/converters/tr.rb
+++ b/lib/reverse_markdown/converters/tr.rb
@@ -1,8 +1,8 @@
 module ReverseMarkdown
   module Converters
     class Tr < Base
-      def convert(node)
-        content = treat_children(node).rstrip
+      def convert(node, state = {})
+        content = treat_children(node, state).rstrip
         result  = "|#{content}\n"
         table_header_row?(node) ? result + underline_for(node) : result
       end

--- a/spec/lib/reverse_markdown/converters/strong_spec.rb
+++ b/spec/lib/reverse_markdown/converters/strong_spec.rb
@@ -10,7 +10,7 @@ describe ReverseMarkdown::Converters::Strong do
 
   it 'returns just the content if the strong tag is nested in another strong' do
     input = node_for('<strong><strong>foo</strong></strong>')
-    expect(converter.convert(input.children.first)).to eq 'foo'
+    expect(converter.convert(input.children.first, already_strong: true)).to eq 'foo'
   end
 
   it 'moves border whitespaces outside of the delimiters tag' do


### PR DESCRIPTION
We are traversing the document top-down, so we shouldn't ever need to traverse back up.  In very large documents, traversing back up can be expensive.  This will pass around a state that can be used to track parent information rather than ascending back up the tree.

:warning: 
This is something I would consider worthy of a major version bump, as it changes the API a little bit. Anyone with currently built custom converters will encounter errors until they modify them to accept the `state` argument and then pass that argument to `treat_children`

Some performance numbers for parsing [this document](https://gist.github.com/craig-day/ba25eab699b164db04d2)
**before**
```
unknown tag mode :pass_through
time: 0.535165

unknown tag mode :drop
time: 0.577383

unknown tag mode :bypass
time: 0.539775
```

**after**
```
unknown tag mode :pass_through
time: 0.080481

unknown tag mode :drop
time: 0.077927

unknown tag mode :bypass
time: 0.051546
```