### PR TITLE
make sure we don't over escape * or _

### DIFF
--- a/lib/reverse_markdown/converters/base.rb
+++ b/lib/reverse_markdown/converters/base.rb
@@ -12,7 +12,7 @@ module ReverseMarkdown
       end
 
       def escape_keychars(string)
-        string.gsub(/[\*\_]/, '*' => '\*', '_' => '\_')
+        string.gsub(/(?<!\\)[*_]/, '*' => '\*', '_' => '\_')
       end
 
       def extract_title(node)

--- a/lib/reverse_markdown/converters/text.rb
+++ b/lib/reverse_markdown/converters/text.rb
@@ -31,14 +31,14 @@ module ReverseMarkdown
 
         text = preserve_keychars_within_backticks(text)
         text = preserve_tags(text)
-        
+
         text
       end
 
       def preserve_nbsp(text)
         text.gsub(/\u00A0/, "&nbsp;")
       end
-      
+
       def preserve_tags(text)
         text.gsub(/[<>]/, '>' => '\>', '<' => '\<')
       end

--- a/spec/assets/from_the_wild.html
+++ b/spec/assets/from_the_wild.html
@@ -17,3 +17,7 @@
     </strong>
   </strong>
 </p>
+
+<a href="example.com/foo_bar">
+  <img src="example.com/foo_bar.png"> I\_AM\_HELPFUL
+</a>

--- a/spec/components/from_the_wild_spec.rb
+++ b/spec/components/from_the_wild_spec.rb
@@ -7,7 +7,11 @@ describe ReverseMarkdown do
   subject { ReverseMarkdown.convert(input) }
 
   it "should make sense of strong-crazy markup (as seen in the wild)" do
-    expect(subject).to eq "**.  \n \\*\\*\\* intentcast** : logo design   \n **.**\n\n"
+    expect(subject).to include "**.  \n \\*\\*\\* intentcast** : logo design   \n **.**\n\n"
+  end
+
+  it "should not over escape * or _" do
+    expect(subject).to include '[![](example.com/foo_bar.png) I\_AM\_HELPFUL](example.com/foo_bar)'
   end
 
 end


### PR DESCRIPTION
Little bit of a weird, but possible scenario.  Right now, we will escape `*` and `_` no matter what. Well, what if they have already been escaped? This modifies the `escape_keychars` function a little bit to make sure that we don't end up with something like `foo\\\\\\\\\\\_bar` when all we want is `foo\_bar`. 