### PR TITLE
remove leading whitespace at the beginning of a new line

### DIFF
--- a/lib/reverse_markdown/cleaner.rb
+++ b/lib/reverse_markdown/cleaner.rb
@@ -6,7 +6,8 @@ module ReverseMarkdown
       result = remove_newlines(result)
       result = remove_leading_newlines(result)
       result = clean_tag_borders(result)
-      clean_punctuation_characters(result)
+      result = clean_punctuation_characters(result)
+      remove_leading_whitespaces(result)
     end
 
     def remove_newlines(string)
@@ -15,6 +16,10 @@ module ReverseMarkdown
 
     def remove_leading_newlines(string)
       string.gsub(/\A\n+/, '')
+    end
+    
+    def remove_leading_whitespaces(string)
+      string.gsub(/\r\s/, "\r")
     end
 
     def remove_inner_whitespaces(string)

--- a/spec/lib/reverse_markdown/cleaner_spec.rb
+++ b/spec/lib/reverse_markdown/cleaner_spec.rb
@@ -14,6 +14,13 @@ describe ReverseMarkdown::Cleaner do
       expect(result).to eq "foo\nbar\n\nbaz"
     end
   end
+  
+  describe '#remove_leading_whitespaces' do
+    it 'removes spaces after line breaks' do
+      result = cleaner.remove_leading_whitespaces("foo\r bar")
+      expect(result).to eq "foo\rbar"
+    end
+  end
 
   describe '#remove_inner_whitespaces' do
     it 'removes duplicate whitespaces from the string' do

--- a/spec/lib/reverse_markdown_spec.rb
+++ b/spec/lib/reverse_markdown_spec.rb
@@ -19,6 +19,14 @@ describe ReverseMarkdown do
   it "behaves in a sane way when root element is nil" do
     expect(ReverseMarkdown.convert(nil)).to eq ''
   end
+  
+  it "does not add whitespace at the beginning of a new line" do
+    ReverseMarkdown.config.unknown_tags = :drop
+    ReverseMarkdown.config.github_flavored = true
+    ReverseMarkdown.config.tag_border = ''
+
+    expect(ReverseMarkdown.convert("Praia Joaquina \r\n\r\nThe spot")).to eq "Praia Joaquina \r\rThe spot\n\n"
+  end
 
   describe '#config' do
     it 'stores a given configuration option' do


### PR DESCRIPTION
`Lorem ipsum \r\nLorem ipsum.`

This kind of input resulted in a whitespace at the beginning of the new line.
