### PR TITLE
Blockquote newline

### DIFF
--- a/lib/reverse_markdown/converters/blockquote.rb
+++ b/lib/reverse_markdown/converters/blockquote.rb
@@ -4,7 +4,7 @@ module ReverseMarkdown
       def convert(node, state = {})
         content = treat_children(node, state).strip
         content = ReverseMarkdown.cleaner.remove_newlines(content)
-        '> ' << content.lines.to_a.join('> ')
+        '> ' << content.lines.to_a.join('> ') << "\n\n"
       end
     end
 

--- a/spec/lib/reverse_markdown/converters/blockquote_spec.rb
+++ b/spec/lib/reverse_markdown/converters/blockquote_spec.rb
@@ -15,4 +15,10 @@ describe ReverseMarkdown::Converters::Blockquote do
     result = converter.convert(input)
     expect(result).to eq "> Some text.\n> \n> Some more text."
   end
+
+  it 'adds a newline after the quote to end it' do
+    input = node_for("<blockquote>  This is a quote </blockquote>\n<img alt=\"alt\" src=\"https://path/to/file.jpg\" />")
+    result = converter.convert(input)
+    expect(result).to eq "> This is a quote\n\n ![alt](https://path/to/file.jpg)"
+  end
 end


### PR DESCRIPTION
add two newlines after the quote to correctly end it (see #67 ).