### PR TITLE
Add treat_children to pre converter

### DIFF
--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -5,7 +5,9 @@ module ReverseMarkdown
         if ReverseMarkdown.config.github_flavored
           "\n```#{language(node)}\n" << node.text.strip << "\n```\n"
         else
-          "\n\n    " << node.text.strip.lines.to_a.join("    ") << "\n\n"
+          treatedChildren = treat_children(node, state).strip
+          treatedChildren = treatedChildren.chomp("`").reverse.chomp("`").reverse if treatedChildren[0] == "`" && treatedChildren[-1] == "`"
+          "\n\n    " << treatedChildren.lines.to_a.join("    ") << "\n\n"
         end
       end
 

--- a/spec/lib/reverse_markdown/converters/pre_spec.rb
+++ b/spec/lib/reverse_markdown/converters/pre_spec.rb
@@ -11,6 +11,11 @@ describe ReverseMarkdown::Converters::Pre do
       node = node_for("<pre>puts foo</pre>")
       expect(converter.convert(node)).to include "    puts foo\n"
     end
+
+    it 'preserves new lines' do
+      node = node_for("<pre>one<br>two<br>three</pre>")
+      expect(converter.convert(node)).to include "\n\n    one  \n    two  \n    three\n\n"
+    end
   end
 
   context 'for github_flavored markdown' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,5 @@ RSpec.configure do |config|
 end
 
 def node_for(html)
-  Nokogiri::XML.parse(html).root
+  Nokogiri::HTML.parse(html).root.child.child
 end


### PR DESCRIPTION
While using this gem, we had an issue where new lines within `pre` code blocks were not being preserved. On inspection, I found that we were recording new lines as `br` tags within the `pre` block, and the existing converter was dropping them with the line `node.text.strip.lines.to_a.join("    ")`.

Since it's permitted to have phrasing content as the children of `pre` nodes, I decided to look for a solution here, using the `treat_children` method to continue to traverse down the tree. This mostly worked, but it messed with some of the spec when a single `code` block was nested in the `pre` block, so I added a line to handle that specific case.

I also noticed the `node_for` function in the `spec_helper` was using `Nokogiri::XML` instead of `Nokogiri::HTML`. It was messing with my tests so I updated it, seems to work with the rest of the spec.