### PR TITLE
Bypass `<tfoot>` tags to match how `<thead>` is handled.

### DIFF
--- a/lib/reverse_markdown/converters/bypass.rb
+++ b/lib/reverse_markdown/converters/bypass.rb
@@ -12,5 +12,6 @@ module ReverseMarkdown
     register :span,     Bypass.new
     register :thead,    Bypass.new
     register :tbody,    Bypass.new
+    register :tfoot,    Bypass.new
   end
 end

--- a/spec/assets/tables.html
+++ b/spec/assets/tables.html
@@ -26,6 +26,13 @@
           <td>data 3-2</td>
         </tr>
       </tbody>
+      <tfoot>
+        <tr>
+          <td>footer 1</td>
+          <td>footer 2</td>
+          <td>footer 3</td>
+        </tr>
+      </tfoot>
     </table>
 
     <table>

--- a/spec/components/tables_spec.rb
+++ b/spec/components/tables_spec.rb
@@ -9,6 +9,7 @@ describe ReverseMarkdown do
   it { is_expected.to match /\n\| header 1 \| header 2 \| header 3 \|\n\| --- \| --- \| --- \|\n/ }
   it { is_expected.to match /\n\| data 1-1 \| data 2-1 \| data 3-1 \|\n/ }
   it { is_expected.to match /\n\| data 1-2 \| data 2-2 \| data 3-2 \|\n/ }
+  it { is_expected.to match /\n\| footer 1 \| footer 2 \| footer 3 \|\n/ }
 
   it { is_expected.to match /\n\| _header oblique_ \| \*\*header bold\*\* \| `header code` \|\n| --- \| --- \| --- \|\n/ }
   it { is_expected.to match /\n\| _data oblique_ \| \*\*data bold\*\* \| `data code` \|\n/ }


### PR DESCRIPTION
This just adds a `register :tfoot, Bypass.new` so that `<tfoot>` is handled the say way as `<thead>`.