### PR TITLE
Add support for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ rvm:
   - 2.3.0
   - 2.3.1
   - 2.4.2
+  - jruby-9.1.16.0
 
 script: "bundle exec rake spec"
 

--- a/lib/reverse_markdown/converters/ignore.rb
+++ b/lib/reverse_markdown/converters/ignore.rb
@@ -8,5 +8,6 @@ module ReverseMarkdown
 
     register :colgroup, Ignore.new
     register :col,      Ignore.new
+    register :head,     Ignore.new
   end
 end

--- a/reverse_markdown.gemspec
+++ b/reverse_markdown.gemspec
@@ -23,7 +23,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'redcarpet'
+  if RUBY_PLATFORM == 'java'
+    s.add_development_dependency 'kramdown'
+  else
+    s.add_development_dependency 'redcarpet'
+  end
   # s.add_development_dependency 'byebug'
   s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/reverse_markdown.gemspec
+++ b/reverse_markdown.gemspec
@@ -23,11 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake'
-  if RUBY_PLATFORM == 'java'
-    s.add_development_dependency 'kramdown'
-  else
-    s.add_development_dependency 'redcarpet'
-  end
+  s.add_development_dependency 'kramdown'
   # s.add_development_dependency 'byebug'
   s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/spec/html_to_markdown_to_html_spec.rb
+++ b/spec/html_to_markdown_to_html_spec.rb
@@ -1,6 +1,10 @@
 # coding:utf-8
 
-require 'redcarpet'
+begin
+  require 'kramdown'
+rescue LoadError
+  require 'redcarpet'
+end
 require 'spec_helper'
 
 describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redcarpet)' do
@@ -9,13 +13,22 @@ describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redca
 
   def roundtrip_should_preserve(input)
     output = html2markdown2html input
-    expect(normalize_html(input)).to eq normalize_html(output)
+    expect(normalize_html(output)).to eq normalize_html(input)
   end
 
-  def html2markdown2html(orig_html)
-    markdown = ReverseMarkdown.convert orig_html
-    new_html = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(markdown)
-    new_html
+  if defined?(Kramdown)
+    def html2markdown2html(orig_html)
+      markdown = ReverseMarkdown.convert orig_html
+      new_html = Kramdown::Document.new(markdown).to_html.gsub(' />', '>')
+      new_html
+    end
+
+  else
+    def html2markdown2html(orig_html)
+      markdown = ReverseMarkdown.convert orig_html
+      new_html = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(markdown)
+      new_html
+    end
   end
 
   def normalize_html(html)

--- a/spec/html_to_markdown_to_html_spec.rb
+++ b/spec/html_to_markdown_to_html_spec.rb
@@ -1,10 +1,6 @@
 # coding:utf-8
 
-begin
-  require 'kramdown'
-rescue LoadError
-  require 'redcarpet'
-end
+require 'kramdown'
 require 'spec_helper'
 
 describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redcarpet)' do
@@ -16,19 +12,10 @@ describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redca
     expect(normalize_html(output)).to eq normalize_html(input)
   end
 
-  if defined?(Kramdown)
-    def html2markdown2html(orig_html)
-      markdown = ReverseMarkdown.convert orig_html
-      new_html = Kramdown::Document.new(markdown).to_html.gsub(' />', '>')
-      new_html
-    end
-
-  else
-    def html2markdown2html(orig_html)
-      markdown = ReverseMarkdown.convert orig_html
-      new_html = Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(markdown)
-      new_html
-    end
+  def html2markdown2html(orig_html)
+    markdown = ReverseMarkdown.convert orig_html
+    new_html = Kramdown::Document.new(markdown).to_html
+    new_html
   end
 
   def normalize_html(html)
@@ -66,7 +53,7 @@ describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redca
   end
 
   it "should preserve <hr> tags" do
-    roundtrip_should_preserve("<hr>")
+    roundtrip_should_preserve("<hr />")
   end
 
   it "should preserve <em> tags" do
@@ -82,7 +69,7 @@ describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redca
   end
 
   it "should preserve <br> tags" do
-    roundtrip_should_preserve("<p>yes!<br>\n we can!</p>")
+    roundtrip_should_preserve("<p>yes!<br />\n we can!</p>")
   end
 
   it "should preserve <a> tags" do
@@ -91,8 +78,8 @@ describe 'Round trip: HTML to markdown (via reverse_markdown) to HTML (via redca
   end
 
   it "should preserve <img> tags" do
-    roundtrip_should_preserve(%{<p><img src="http://foo.bar/dog.png" alt="My Dog" title="Ralph"></p>})
-    roundtrip_should_preserve(%{<p><img src="http://foo.bar/dog.png" alt="My Dog"></p>})
+    roundtrip_should_preserve(%{<p><img src="http://foo.bar/dog.png" alt="My Dog" title="Ralph" /></p>})
+    roundtrip_should_preserve(%{<p><img src="http://foo.bar/dog.png" alt="My Dog" /></p>})
   end
 
   it "should preserve code blocks" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,5 +17,5 @@ RSpec.configure do |config|
 end
 
 def node_for(html)
-  Nokogiri::HTML.parse(html).root.child.child
+  Nokogiri::HTML.parse(html).root.children.last.child
 end


### PR DESCRIPTION
It seems the JRuby version of Nokogiri explicitly includes an empty head element when parsing a HTML fragment using `Nokogiri::HTML(fragment)`, whereas the MRI version does not. While it would be reasonable for Nokogiri to behave the same way on all platforms, it's not obvious whether that would be to remove head or to always include it, and given that the simple workaround to ignore head elements is sufficient to support both, it seems reasonable to not wait until Nokogiri is updated.

In order to avoid similar issues creeping up in the future, this adds a JRuby target to Travis, and patches the test suite to be compatible. In addition to handling the head element in `node_for`, it meant replacing redcarpet that requires a C-extension with pure Ruby kramdown instead.

While I suppose kramdown could be used for all targets, the current implementation keeps using redcarpet unless we are using JRuby, which effectively means that the test-suite ensure compatiblity with both.