### PR TITLE
Reduce warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,5 +10,5 @@ task :default => :spec
 
 desc 'Open an irb session preloaded with this library'
 task :console do
-  sh 'irb -rubygems -I lib -r reverse_markdown.rb'
+  sh 'irb -I lib -r reverse_markdown.rb'
 end

--- a/lib/reverse_markdown/config.rb
+++ b/lib/reverse_markdown/config.rb
@@ -1,6 +1,6 @@
 module ReverseMarkdown
   class Config
-    attr_accessor :unknown_tags, :github_flavored, :tag_border, :force_encoding
+    attr_writer :unknown_tags, :github_flavored, :tag_border, :force_encoding
 
     def initialize
       @unknown_tags     = :pass_through

--- a/reverse_markdown.gemspec
+++ b/reverse_markdown.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Convert html code into markdown.}
   s.description = %q{Map simple html back into markdown, e.g. if you want to import existing html data in your application.}
   s.licenses    = ["WTFPL"]
-  s.rubyforge_project = "reverse_markdown"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
This pull request reduces warnings.


# Remove rubyforge_project from gemspec


https://github.com/xijo/reverse_markdown/commit/1880de49fc5dc8e5500247b5ded2803566a9c886


It removes `s.rubyforge_project = "reverse_markdown"`. Because rubygems displays the following warning.

```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/pocke/ghq/github.com/xijo/reverse_markdown/reverse_markdown.gemspec:14.
```



# Remove `-rubygems` from argument of IRB


https://github.com/xijo/reverse_markdown/commit/af11e53e750e388ad8db76ae327a462cd788d187


`rake console` displays a `LoadError`, since Ruby 2.5.

```bash
$ bundle exec rake console
irb -rubygems -I lib -r reverse_markdown.rb
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/irb/init.rb:290: warning: LoadError: cannot load such file -- ubygems
irb(main):001:0> 
```

Becuase `ubygems` has been removed since Ruby 2.5. And it is unnecessary since Ruby 1.9.
So we can just remove it.
ref: https://www.engineyard.com/blog/goodbye-ubygems



By the way, I'm not sure why IRB only displays LoadError, not exits. :thinking: 


# Reduce Ruby warnings

https://github.com/xijo/reverse_markdown/commit/77dab445c228832651f5012fcfff947e0d962c96


Ruby displays warnings for `config.rb` with `-w` option.


```bash
$ ruby -Ilib -rreverse_markdown -w -e '' 
/home/pocke/ghq/github.com/xijo/reverse_markdown/lib/reverse_markdown/config.rb:22: warning: method redefined; discarding old unknown_tags
/home/pocke/ghq/github.com/xijo/reverse_markdown/lib/reverse_markdown/config.rb:26: warning: method redefined; discarding old github_flavored
/home/pocke/ghq/github.com/xijo/reverse_markdown/lib/reverse_markdown/config.rb:30: warning: method redefined; discarding old tag_border
/home/pocke/ghq/github.com/xijo/reverse_markdown/lib/reverse_markdown/config.rb:34: warning: method redefined; discarding old force_encoding
```



Config uses `attr_accessor`, but it also defines readers, so it warns.


```ruby
# It defines `unknown_tags` and `unknown_tags=`, and so on
attr_accessor :unknown_tags, :github_flavored, :tag_border, :force_encoding

# It overrides the method defined by attr_accessor.
def unknown_tags
  # ...
end
```


So I replace `attr_accessor` with `attr_writer`. It does not affect behavior.

----


Thank you for the great product!