### PR TITLE
Remove `require 'digest'` because it is no longer used

### DIFF
--- a/lib/reverse_markdown.rb
+++ b/lib/reverse_markdown.rb
@@ -1,4 +1,3 @@
-require 'digest'
 require 'nokogiri'
 require 'reverse_markdown/version'
 require 'reverse_markdown/errors'


### PR DESCRIPTION
This require is added in f21bd4973d57ec0b78f480d19aa8ad71cc6b24a7,
but it is no longer used since 24fca82fc4c65056f27b27af0b6cb2d05fe9f30b.