### PR TITLE
Travis: Drop commented-out section, add language

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-# before_install:
-#   - gem install bundler
+language: ruby
 
 rvm:
   - 1.9.3


### PR DESCRIPTION
The language key is included in all the documentation examples.