### PR TITLE
Test only one patch version, add Ruby 2.7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
 language: ruby
+cache: bundler
 
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.1.5
-  - 2.2.0
-  - 2.2.4
-  - 2.2.5
-  - 2.3.0
-  - 2.3.1
-  - 2.4.2
-  - 2.5.3
-  - 2.6.2
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-9.2.8.0
-
-script: "bundle exec rake spec"
 
 notifications:
   disabled: false


### PR DESCRIPTION
Unless there's a reason to test certain patch versions, this change will make Travis pick the latest available patch version. It will also reduce test times.

`cache: bundler` should also speed up future CI runs.

`script:` was removed, since the default task runs RSpec and `rake` is being [run by Travis](https://docs.travis-ci.com/user/languages/ruby/#default-build-script)

https://github.com/xijo/reverse_markdown/blob/e2c6973358d160214a79228b286cf55d57c1ae70/Rakefile#L8-L9