### PR TITLE
Fixes unintentional newline characters within lists with paragraphs

### DIFF
--- a/lib/reverse_markdown/converters/li.rb
+++ b/lib/reverse_markdown/converters/li.rb
@@ -2,8 +2,8 @@ module ReverseMarkdown
   module Converters
     class Li < Base
       def convert(node, state = {})
-        contains_child_paragraph = node.children.first ? node.children.first.name == 'p' : false
-        content_node             = contains_child_paragraph ? node.children.first : node
+        contains_child_paragraph = node.first_element_child ? node.first_element_child.name == 'p' : false
+        content_node             = contains_child_paragraph ? node.first_element_child : node
         content                  = treat_children(content_node, state)
         indentation              = indentation_from(state)
         prefix                   = prefix_for(node)

--- a/spec/assets/lists.html
+++ b/spec/assets/lists.html
@@ -44,6 +44,8 @@
       </li>
     </ul>
 
+    <ul><li> <p>I don't want to cleanup after the party!</p> </li></ul>
+
     <ul>
       <li>
         <p>li 1, p 1</p>

--- a/spec/components/lists_spec.rb
+++ b/spec/components/lists_spec.rb
@@ -35,7 +35,8 @@ describe ReverseMarkdown do
   end
 
   context "lists containing embedded <p> tags" do
-    xit { is_expected.to match /\n- I want to have a party at my house!\n/ }
+    it { is_expected.to match /\n- I want to have a party at my house!\n/ }
+    it { is_expected.to match /\n- I don't want to cleanup after the party!\n/ }
   end
 
   context "list item containing multiple <p> tags" do


### PR DESCRIPTION
This commit aims to fix a problem when parsing markup similar to:

```ruby
[8] pry(main)> ReverseMarkdown.convert("<ul><li> <p>a</p></li></ul>")
=> "-  \n\na\n\n"
```

Note that the list item has newlines between the markdown list item and
the actual text.

If you remove the space between the list item tag and the paragraph tag:

```ruby
[7] pry(main)> ReverseMarkdown.convert("<ul><li><p>a</p></li></ul>")
=> "- a\n\n"
```

Reverse markdown appears to assume what believe to be the intended
behaviour. There was already a test in place to account for this situation,
but it was `xit`'ed.

The proposed patch is to ask Nokogiri to find the first child element of
the list, instead of the first child (which might include stuff like a
newline).