### PR TITLE
Add support for parsing  prism style class="language-ts"

### DIFF
--- a/lib/reverse_markdown/converters/pre.rb
+++ b/lib/reverse_markdown/converters/pre.rb
@@ -27,14 +27,19 @@ module ReverseMarkdown
       def language(node)
         lang = language_from_highlight_class(node)
         lang || language_from_confluence_class(node)
+        lang || language_from_language_class(node)
       end
 
       def language_from_highlight_class(node)
         node.parent['class'].to_s[/highlight-([a-zA-Z0-9]+)/, 1]
       end
-
+      
       def language_from_confluence_class(node)
         node['class'].to_s[/brush:\s?(:?.*);/, 1]
+      end
+
+      def language_from_language_class(node)
+        node.parent['class'].to_s[/language-([a-zA-Z0-9]+)/, 1]
       end
     end
 


### PR DESCRIPTION
Prism which is a common code highlighting library uses the `language-` class structure. It seems like a good idea to support that too.

https://prismjs.com/#examples