### PR TITLE
Fix text sticking after list

### DIFF
--- a/lib/reverse_markdown/converters/ol.rb
+++ b/lib/reverse_markdown/converters/ol.rb
@@ -3,7 +3,7 @@ module ReverseMarkdown
     class Ol < Base
       def convert(node, state = {})
         ol_count = state.fetch(:ol_count, 0) + 1
-        "\n" << treat_children(node, state.merge(ol_count: ol_count))
+        "\n" << treat_children(node, state.merge(ol_count: ol_count)) << "\n"
       end
     end
 

--- a/reverse_markdown.gemspec
+++ b/reverse_markdown.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'kramdown'
-  s.add_development_dependency 'byebug'
+  s.add_development_dependency 'debug'
   s.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/spec/assets/lists.html
+++ b/spec/assets/lists.html
@@ -95,5 +95,10 @@
       <li>delta</li>
     </ul>
 
+    <ul>
+      <li>item followed with a text</li>
+    </ul>
+    text after the list
+
   </body>
 </html>

--- a/spec/components/lists_spec.rb
+++ b/spec/components/lists_spec.rb
@@ -65,4 +65,7 @@ describe ReverseMarkdown do
     it { is_expected.to match /\n- delta\n/ }
   end
 
+  context "text following list should have a new line separator" do
+    it { is_expected.to match /\n- item followed with a text\n\n text after the list/ }
+  end
 end

--- a/spec/lib/reverse_markdown_spec.rb
+++ b/spec/lib/reverse_markdown_spec.rb
@@ -36,7 +36,7 @@ describe ReverseMarkdown do
 
     describe 'force_encoding option', jruby: :exclude do
       it 'raises invalid byte sequence in UTF-8 exception' do
-        expect { ReverseMarkdown.convert("hi \255") }.to raise_error(ArgumentError)
+        expect { ReverseMarkdown.convert("hi \255") }.to raise_error(Encoding::CompatibilityError)
       end
 
       it 'handles invalid byte sequence if option is set' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'simplecov'
-# require 'byebug'
+require 'debug'
 
 SimpleCov.profiles.define 'gem' do
   add_filter '/spec/'


### PR DESCRIPTION
I have an issue when parsing text after a list.
```
<ul>
  <li>item followed with a text</li>
</ul>
text after the list
```
This HTML is parsed as:
```
- item followed with a text
 text after the list
```
But this markdown will collapse `text after the list` with `item followed with a text`.
We can check [here](https://spec.commonmark.org/dingus/?text=-%20liste%20avec%20un%20espace%0A%20hors-liste) the result.

With this changes, the new output is:
```
- item followed with a text

text after the list
```
And now, we don't have the text outside the list collapsed with the last list item.
We can check [here](https://spec.commonmark.org/dingus/?text=-%20item%20followed%20with%20a%20text%0A%0Atext%20after%20the%20list) again.

PS: I fixed a other test about UTF-8, I think that nokogiri changes the way it break with encoding.
PS2: I switched `byebug` by `ruby/debug`